### PR TITLE
Fix for IE8

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -68,7 +68,7 @@
                 return this.each(function() {
                     var stickyElement = $(this);
 
-                    stickyId = stickyElement.attr('id');
+                    var stickyId = stickyElement.attr('id');
                     var wrapper = $('<div></div>')
                         .attr('id', stickyId + '-sticky-wrapper')
                         .addClass(o.wrapperClassName);

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -69,7 +69,7 @@
                     var stickyElement = $(this);
 
                     stickyId = stickyElement.attr('id');
-                    wrapper = $('<div></div>')
+                    var wrapper = $('<div></div>')
                         .attr('id', stickyId + '-sticky-wrapper')
                         .addClass(o.wrapperClassName);
                     stickyElement.wrapAll(wrapper);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jquery-sticky",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Sticky is a jQuery plugin that gives you the ability to make any element on your page always stay visible.",
     "categories": [ "UI", "DOM" ],
     "author": {


### PR DESCRIPTION
Message: Object doesn't support this property or method

It happens with IE8 standards document mode.
